### PR TITLE
Adding a test group to commands for terminal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ To help develop redshrits we implemented a local mode chat server that disables
 gRPC authentication. This is meant only for local development. It can also be a
 way to play with Riker.
 
+You can set the nickname of the terminal mode user and the groups that the user belongs to using
+the command line options --nickname and --groups. Groups should be a comma seperated list of group
+names.
 
 Components
 ==========

--- a/cmd/terminalbot.go
+++ b/cmd/terminalbot.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/pantheon-systems/riker/pkg/chat/terminalbot"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -17,7 +20,28 @@ var terminalCmd = &cobra.Command{
 	Run: startTerminalBot,
 }
 
+func init() {
+	terminalCmd.PersistentFlags().String(
+		"nickname",
+		"some-nickname",
+		"The nickname to send messages as",
+	)
+
+	terminalCmd.PersistentFlags().String(
+		"groups",
+		"infra,eng",
+		"The groups that the sending user belongs",
+	)
+	// binding flags to viper
+	terminalCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		viper.BindPFlag(f.Name, f)
+	})
+
+}
+
 func startTerminalBot(cmd *cobra.Command, args []string) {
-	b := terminalbot.New(viper.GetString("bind-address"))
+	nickname := viper.GetString("nickname")
+	groups := strings.Split(viper.GetString("groups"), ",")
+	b := terminalbot.New(viper.GetString("bind-address"), nickname, groups)
 	b.Run()
 }

--- a/pkg/chat/terminalbot/terminalbot.go
+++ b/pkg/chat/terminalbot/terminalbot.go
@@ -31,9 +31,12 @@ type TerminalBot struct {
 
 	grpc *grpc.Server
 	gui  *gocui.Gui
+
+	nickname string
+	groups   []string
 }
 
-func New(addr string) *TerminalBot {
+func New(addr string, nickname string, groups []string) *TerminalBot {
 	k := keepalive.ServerParameters{
 		Time:    3 * time.Second,
 		Timeout: 15 * time.Second,
@@ -49,6 +52,8 @@ func New(addr string) *TerminalBot {
 		listenAddr: addr,
 		gui:        g,
 		grpc:       grpcServer,
+		nickname:   nickname,
+		groups:     groups,
 		redshirts:  make(map[string]*redshirtRegistration, 10),
 	}
 	t.RWMutex = &sync.RWMutex{}

--- a/pkg/chat/terminalbot/ui.go
+++ b/pkg/chat/terminalbot/ui.go
@@ -185,7 +185,8 @@ func (t *TerminalBot) writeView(name, text string) {
 		ThreadTs:  ts.String(),
 
 		Payload:  text,
-		Nickname: "user",
+		Groups:   t.groups,
+		Nickname: t.nickname,
 	}
 
 	log.Printf("sending msg to redshirt: %v\n", msg)


### PR DESCRIPTION
Problem: Cannot test group based auth for redshirt wrappers or anything being developed against for riker in terminal mode

Solution: this should be some kind of config option for terminal mode that can set the group of the messages being sent from the terminal mode UI. Also for nickname as well.