### PR TITLE
Fixup api deprecation

### DIFF
--- a/pkg/chat/slackbot/slack.go
+++ b/pkg/chat/slackbot/slack.go
@@ -223,10 +223,10 @@ func New(name, bindAddr, botKey, token, tlsFile, caFile string, allowedOUs []str
 		redshirts: make(map[string]*redshirtRegistration, 10),
 	}
 
-	/*_, err = b.rtm.AuthTest()
+	_, err = b.rtm.AuthTest()
 	if err != nil {
 		return nil, err
-	}*/
+	}
 
 	grpcServer := grpc.NewServer(
 		grpc.KeepaliveParams(k),


### PR DESCRIPTION
This broke due to an API deprecation at Slack, see
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api

Also don't run if the API token is no good.