### PR TITLE
fix: use certinel instead of go-certauth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/nsf/termbox-go v1.1.0 // indirect
-	github.com/pantheon-systems/go-certauth v0.0.0-20170606170341-8764720d23a5
+	github.com/pantheon-systems/certinel v1.2.1
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fsnotify/fsnotify v1.4.2/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -172,8 +173,8 @@ github.com/nsf/termbox-go v1.1.0 h1:R+GIXVMaDxDQ2VHem5vO5h0mI8ZxLECTUNw1ZzXODzI=
 github.com/nsf/termbox-go v1.1.0/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/pantheon-systems/go-certauth v0.0.0-20170606170341-8764720d23a5 h1:3TrlFdAhpwWyWVvOGKx4Wl57P4n8nOFPVd1xzdiZfvE=
-github.com/pantheon-systems/go-certauth v0.0.0-20170606170341-8764720d23a5/go.mod h1:2sJTloscUWdkpwhzz51BDWf1tHtOUGJrQEgr96uFurg=
+github.com/pantheon-systems/certinel v1.2.1 h1:zGV5lPtkR/DHyIGSDgRVPvSza7558suZPWzKlcdlonY=
+github.com/pantheon-systems/certinel v1.2.1/go.mod h1:HAXqqHlUtcD4gQvtZfAu8CeS9Jbq41yBZFnHjQRNcqI=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
@@ -235,6 +236,7 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/chat/slackbot/slack.go
+++ b/pkg/chat/slackbot/slack.go
@@ -29,6 +29,8 @@ import (
 	"github.com/slack-go/slack"
 )
 
+var interval = 10 * time.Second
+
 // holds info on a connected client (redshirt) so we can send it data
 type redshirtRegistration struct {
 	queue      chan *botpb.Message
@@ -176,20 +178,15 @@ func (b *SlackBot) HealthZ() error {
 }
 
 // New is the constroctor for a bot
-func New(name, bindAddr, botKey, token, tlsFile, caFile, duration string, allowedOUs []string, log *logrus.Logger) (riker.Bot, error) {
+func New(name, bindAddr, botKey, token, tlsFile, caFile string, allowedOUs []string, log *logrus.Logger) (riker.Bot, error) {
 	if log == nil {
 		log = logrus.New()
 	}
 
-	interval, err := time.ParseDuration(duration)
-	if err != nil {
-		return nil, fmt.Errorf("Could not parse duration (%s) for tls: %s", duration, err.Error())
-	}
-
-	watcher := pollwatcher.New(tlsFile, caFile, interval)
+	watcher := pollwatcher.New(tlsFile, tlsFile, interval)
 
 	sentinel := certinel.New(watcher, nil, func(err error) {
-		fmt.Errorf("certinel was unable to reload the certificate: %s", err)
+		fmt.Printf("certinel was unable to reload the certificate: %s", err)
 	})
 	sentinel.Watch()
 

--- a/pkg/redshirt/client.go
+++ b/pkg/redshirt/client.go
@@ -11,17 +11,14 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+var interval = 10 * time.Second
+
 // NewTLSConnection will initiate a connection to riker with given address caFile and client .pem
 func NewTLSConnection(addr, caFile, tlsFile, duration string) (*grpc.ClientConn, error) {
-	interval, err := time.ParseDuration(duration)
-	if err != nil {
-		return nil, fmt.Errorf("Could not parse duration (%s) for tls: %s", duration, err.Error())
-	}
-
-	watcher := pollwatcher.New(tlsFile, caFile, interval)
+	watcher := pollwatcher.New(tlsFile, tlsFile, interval)
 
 	sentinel := certinel.New(watcher, nil, func(err error) {
-		fmt.Errorf("certinel was unable to reload the certificate: %s", err)
+		fmt.Printf("certinel was unable to reload the certificate: %s", err)
 	})
 	sentinel.Watch()
 


### PR DESCRIPTION
The following patch introduces potential modifications to use pantheon's certinal instead of go-certauth #16 